### PR TITLE
Presentation with item binding

### DIFF
--- a/Sources/PopupKit/Cover/CoverModifier.swift
+++ b/Sources/PopupKit/Cover/CoverModifier.swift
@@ -61,6 +61,53 @@ public extension View {
         )
         #endif
     }
+    
+    /// Presents a cover with **PopupKit**.
+    ///
+    /// Cover is similar to system sheet. Cover is screen-wide view with configurable height, attached to top or bottom edge of the screen.
+    /// Anchor screen edge is provided by calling ``View/coverRoot(:_)``.
+    ///
+    /// To create a cover you provide a view to display and background style.
+    /// Also you can adjust a radius of cover's corners and set a modality mode to it.
+    /// Modality determines if user is able to interact with views under this cover and with cover itself.
+    /// Learn more about modality at ``Modality``
+    ///
+    /// - Parameters:
+    ///    - item: An `Identifiable?` value that determines whether
+    ///  to present the view that you create in the modifier's `content` closure.
+    ///    - background: Background style of the presentable view.
+    ///    - modal: Modality of the presentable view.
+    ///    - cornerRadius: Radius of all cornrers of the presentable view.
+    ///    - content: A closure that returns the content of the notification.
+    ///
+    /// - Note: Requires a ``View/coverRoot(:_)`` been called higher up the view hierarchy.
+    ///
+    func cover<Content: View, S: ShapeStyle, Item: Identifiable>(
+        item: Binding<Item?>,
+        background: S = .background,
+        modal: Modality = .modal(interactivity: .interactive),
+        cornerRadius: Double = 20.0,
+        content: @escaping (Item) -> Content
+    ) -> some View {
+        cover(
+            isPresented: Binding(
+                get: { item.wrappedValue != nil },
+                set: { if !$0 { item.wrappedValue = nil } }
+            ),
+            background: background,
+            modal: modal,
+            cornerRadius: cornerRadius,
+            content: {
+                Group {
+                    if let wrapped = item.wrappedValue {
+                        content(wrapped)
+                    } else {
+                        EmptyView()
+                    }
+                }
+            }
+        )
+    }
 }
 
 struct CoverModifier<T: View, S: ShapeStyle>: ViewModifier {

--- a/Sources/PopupKit/Fullscreen/FullscreenModifier.swift
+++ b/Sources/PopupKit/Fullscreen/FullscreenModifier.swift
@@ -62,6 +62,54 @@ public extension View {
         )
         #endif
     }
+    
+    /// Presents a fullscreen with **PopupKit**.
+    ///
+    /// Fullscreen is similar to system *fullscreenCover*. Fullscreen covers the screen space entirely.
+    /// Fullscreen respects device's safe area and provides a way to manage it.
+    ///
+    /// To create a fullscreen you provide a view to display and a background style.
+    /// You can specify which of *safe area* insets will be ignored by a view when displaying.
+    /// Note that the background of fullscreen ignores this setting and fills the screen space entirely.
+    /// Also you can configure a *dismiss-on-scroll* behavoiur (``DismissalScroll``) - provide an appropriate
+    /// translation needed for fullscreen to dismiss or disable this feature.
+    ///
+    /// - Parameters:
+    ///    - item: An `Identifiable?` value that determines whether
+    ///  to present the view that you create in the modifier's `content` closure.
+    ///    - background: Background style of the presentable view.
+    ///    - ignoresEdges: A set of safe area edges to be ignored by the *content*.
+    ///    - dismissalScroll: A view behavoiur on scrolling down.
+    ///    - content: A closure that returns the content of the notification.
+    ///
+    /// - Note: Requires a ``View/fullscreenRoot(:_)`` been called higher up the view hierarchy.
+    ///
+    func fullscreen<Content: View, Style: ShapeStyle, Item: Identifiable>(
+        item: Binding<Item?>,
+        background: Style = .background,
+        ignoresEdges: Edge.Set = [],
+        dismissalScroll: DismissalScroll = .dismiss(predictedThreshold: 500),
+        content: @escaping (Item) -> Content
+    ) -> some View {
+        fullscreen(
+            isPresented: Binding(
+                get: { item.wrappedValue != nil },
+                set: { if !$0 { item.wrappedValue = nil } }
+            ),
+            background: background,
+            ignoresEdges: ignoresEdges,
+            dismissalScroll: dismissalScroll,
+            content: {
+                Group {
+                    if let wrapped = item.wrappedValue {
+                        content(wrapped)
+                    } else {
+                        EmptyView()
+                    }
+                }
+            }
+        )
+    }
 }
 
 struct FullscreenModifier<T: View, S: ShapeStyle>: ViewModifier {


### PR DESCRIPTION
Added an option to present a cover or fullscreen with a binding to identifiable type